### PR TITLE
all: Implement log streaming

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,9 +1,16 @@
 issues:
   exclude-use-default: false
   exclude-rules:
-    - path: cmd/telejob/main_test\.go
+    - path: cmd/telejob/main_test.go
       linters:
+        - gosec
+        - ireturn
         - paralleltest
+        - wrapcheck
+    - path: pkg/job/logs_test.go
+      linters:
+        - gosec
+        - testpackage
 linters:
   enable-all: true
   disable:

--- a/README.md
+++ b/README.md
@@ -135,10 +135,16 @@ To execute a full CI run locally run:
 
     just ci
 
-Stress test with a numeric argument specifying the number of concurrent jobs
-(maximum: ~9000, limited by Go's runtime):
+To execute stress tests, run `just stress` with optional arguments:
 
-    just stress JOBS
+    just stress JOBS=100 LOG_READERS=100 ADDRESS=""
+
+This build target accepts optional arguments: `JOBS` for the number of
+concurrent jobs to start (maximum: ~9000, limited by Go's runtime) and
+`LOG_READERS` for the number of concurrent log readers streaming logs. There
+is also an optional `ADDRESS` argument to specify an external telejob server,
+which can be useful for inspecting logs. If `ADDRESS` is not set, an internal
+test server is started on a free port and stopped after the tests complete.
 
 All other targets can be listed with `just --list`.
 
@@ -176,6 +182,21 @@ example:
     just run status <ID>
     just run stop <ID>
     just run status <ID>
+
+To test log streaming run:
+
+    touch /tmp/logs
+    just run start -- tail --follow /tmp/logs
+    just run logs <ID>
+
+In a separate terminal, append data to `/tmp/logs` and start another log reader:
+
+    echo "Hello" >> /tmp/logs
+    just run logs <ID>
+
+Repeat the last two commands in separate terminals and observe how all log
+readers receive new data, even after canceling some readers or stopping the
+initial `tail` job.
 
 ## Build and Run
 

--- a/cmd/telejob/main_test.go
+++ b/cmd/telejob/main_test.go
@@ -2,21 +2,35 @@ package main
 
 import (
 	"bytes"
+	"context"
+	"flag"
 	"fmt"
 	"io"
 	"math/rand/v2"
 	"net"
+	"os"
+	"path/filepath"
+	"strconv"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/alecthomas/kong"
 	"github.com/juliaogris/telejob/pkg/job"
+	"github.com/juliaogris/telejob/pkg/pb"
 	"github.com/juliaogris/telejob/pkg/telejob"
 	"github.com/stretchr/testify/require"
 )
 
+//nolint:gochecknoglobals
+var (
+	readerCount = flag.Int("readers", 100, "number of concurrent log readers")
+	address     = flag.String("address", "", "server address")
+)
+
 func TestMainSimple(t *testing.T) {
-	ts := newTestServer(t, "testdata/client-ca.crt")
+	ts := newTestServer(t)
 	defer ts.Stop()
 	t.Setenv("TELEJOB_ADDRESS", ts.address)
 	t.Setenv("TELEJOB_CLIENT_CERT", "testdata/client1.crt")
@@ -58,27 +72,202 @@ func TestMainSimple(t *testing.T) {
 	require.Equal(t, "", out)
 }
 
+func TestMainLogs(t *testing.T) {
+	ts := newTestServer(t)
+	defer ts.Stop()
+	t.Setenv("TELEJOB_ADDRESS", ts.address)
+	t.Setenv("TELEJOB_CLIENT_CERT", "testdata/client1.crt")
+	t.Setenv("TELEJOB_CLIENT_KEY", "testdata/client1.key")
+	t.Setenv("TELEJOB_SERVER_CA_CERT", "testdata/server-ca.crt")
+	out, err := run(t, []string{"start", "echo", "hello"})
+	require.NoError(t, err)
+	id := strings.TrimSpace(out)
+	out, err = run(t, []string{"logs", id})
+	require.NoError(t, err)
+	require.Equal(t, "hello\n", out)
+}
+
+func TestMainLogsStreamed(t *testing.T) {
+	ts := newTestServer(t)
+	defer ts.Stop()
+	t.Setenv("TELEJOB_ADDRESS", ts.address)
+	t.Setenv("TELEJOB_CLIENT_CERT", "testdata/client1.crt")
+	t.Setenv("TELEJOB_CLIENT_KEY", "testdata/client1.key")
+	t.Setenv("TELEJOB_SERVER_CA_CERT", "testdata/server-ca.crt")
+
+	fname := filepath.Join(t.TempDir(), "logs")
+	f, err := os.OpenFile(fname, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	require.NoError(t, err)
+	defer func() { _ = f.Close() }()
+
+	out, err := run(t, []string{"start", "--", "tail", "-f", fname})
+	require.NoError(t, err)
+	id := strings.TrimSpace(out)
+	str, err := start(t, []string{"logs", id})
+	require.NoError(t, err)
+	require.Equal(t, "", str.String())
+
+	mustWrite(t, f, "1\n")
+	wantLogs := "1\n"
+	logsEqual := func() bool { return wantLogs == str.String() }
+	require.Eventually(t, logsEqual, time.Second, 10*time.Millisecond, str.String())
+
+	mustWrite(t, f, "2\n")
+	wantLogs = "1\n2\n"
+	require.Eventually(t, logsEqual, time.Second, 10*time.Millisecond, str.String())
+
+	// Add new log reading client and cancel
+	s, err := receiveOnce(ts.address, id)
+	require.NoError(t, err)
+	require.Equal(t, wantLogs, s)
+
+	mustWrite(t, f, "3\n")
+	wantLogs = "1\n2\n3\n"
+	require.Eventually(t, logsEqual, time.Second, 10*time.Millisecond, str.String())
+
+	_, err = run(t, []string{"stop", id})
+	require.NoError(t, err)
+
+	out, err = run(t, []string{"logs", id})
+	require.NoError(t, err)
+	require.Equal(t, wantLogs, out)
+}
+
+func TestMainManyLogsStreamed(t *testing.T) {
+	ts := newTestServer(t)
+	defer ts.Stop()
+	t.Setenv("TELEJOB_ADDRESS", ts.address)
+	t.Setenv("TELEJOB_CLIENT_CERT", "testdata/client1.crt")
+	t.Setenv("TELEJOB_CLIENT_KEY", "testdata/client1.key")
+	t.Setenv("TELEJOB_SERVER_CA_CERT", "testdata/server-ca.crt")
+
+	fname := filepath.Join(t.TempDir(), "logs")
+	f, err := os.OpenFile(fname, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	require.NoError(t, err)
+	defer func() { _ = f.Close() }()
+
+	out, err := run(t, []string{"start", "--", "tail", "-f", fname})
+	require.NoError(t, err)
+	id := strings.TrimSpace(out)
+	strs := make([]fmt.Stringer, *readerCount)
+	wantLogs := ""
+
+	for i := range strs {
+		strs[i], err = start(t, []string{"logs", id})
+		require.NoError(t, err)
+		text := strconv.Itoa(i) + "\n"
+		mustWrite(t, f, text)
+		wantLogs += text
+		s, err := receiveOnce(ts.address, id)
+		require.NoError(t, err)
+		wantOnceChunk := wantLogs[:min(len(wantLogs), telejob.LogChunkSize)]
+		require.Equal(t, wantOnceChunk, s)
+	}
+
+	_, err = run(t, []string{"stop", id})
+	require.NoError(t, err)
+	stoppedFn := func() bool {
+		out, err := run(t, []string{"status", id})
+		require.NoError(t, err)
+		return strings.Contains(out, "stopped")
+	}
+	require.Eventually(t, stoppedFn, 5*time.Second, 10*time.Millisecond)
+
+	for _, str := range strs {
+		fn := func() bool { return wantLogs == str.String() }
+		require.Eventually(t, fn, 5*time.Second, 10*time.Millisecond, str.String())
+	}
+}
+
+func mustWrite(t *testing.T, f *os.File, s string) {
+	t.Helper()
+	_, err := f.WriteString(s)
+	require.NoError(t, err)
+}
+
+func receiveOnce(addr, id string) (string, error) {
+	client, err := telejob.NewClient(addr, "testdata/client1.crt", "testdata/client1.key", "testdata/server-ca.crt")
+	if err != nil {
+		return "", err
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	stream, err := client.Logs(ctx, &pb.LogsRequest{Id: id})
+	if err != nil {
+		cancel()
+		return "", err
+	}
+	resp, err := stream.Recv()
+	cancel()
+	if err != nil {
+		return "", err
+	}
+	return string(resp.GetChunk()), nil
+}
+
 func run(t *testing.T, args []string) (string, error) {
 	t.Helper()
 	buf := &bytes.Buffer{}
-	var w io.Writer = buf
-	opts := []kong.Option{
-		kong.Exit(exitFatalFn(t)),
-		kong.Bind(&w),
-	}
-	parser, err := kong.New(&app{}, opts...)
+	kctx, err := setupRun(t, args, buf)
 	if err != nil {
-		return "", fmt.Errorf("kong.New: %w", err)
-	}
-	kctx, err := parser.Parse(args)
-	if err != nil {
-		return "", fmt.Errorf("kong.Parser.Parse: %w", err)
+		return "", err
 	}
 	err = kctx.Run()
 	if err != nil {
 		return "", fmt.Errorf("kong.Context.Run: %w", err)
 	}
 	return buf.String(), nil
+}
+
+func start(t *testing.T, args []string) (fmt.Stringer, error) {
+	t.Helper()
+	syncBuf := &syncBuf{}
+	kctx, err := setupRun(t, args, syncBuf)
+	if err != nil {
+		return nil, err
+	}
+	go func() {
+		err := kctx.Run()
+		if err != nil {
+			t.Errorf("kong.Context.Run: %v", err)
+		}
+	}()
+	return syncBuf, nil
+}
+
+func setupRun(t *testing.T, args []string, w io.Writer) (*kong.Context, error) {
+	t.Helper()
+
+	opts := []kong.Option{
+		kong.Exit(exitFatalFn(t)),
+		kong.Bind(&w),
+	}
+	parser, err := kong.New(&app{}, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("kong.New: %w", err)
+	}
+	kctx, err := parser.Parse(args)
+	if err != nil {
+		return nil, fmt.Errorf("kong.Parser.Parse: %w", err)
+	}
+	return kctx, nil
+}
+
+type syncBuf struct {
+	mutex sync.Mutex
+	data  []byte
+}
+
+func (sb *syncBuf) Write(b []byte) (int, error) {
+	sb.mutex.Lock()
+	defer sb.mutex.Unlock()
+	sb.data = append(sb.data, b...)
+	return len(b), nil
+}
+
+func (sb *syncBuf) String() string {
+	sb.mutex.Lock()
+	defer sb.mutex.Unlock()
+	return string(sb.data)
 }
 
 func exitFatalFn(t *testing.T) func(c int) {
@@ -94,15 +283,23 @@ type testServer struct {
 	address string
 }
 
-func newTestServer(t *testing.T, clientCA string) *testServer {
+func (ts *testServer) Stop() {
+	if ts.Server != nil {
+		ts.Server.Stop()
+	}
+}
+
+func newTestServer(t *testing.T) *testServer {
 	t.Helper()
 	opts := []job.Option{
-		//nolint:gosec // G404: Use of weak random number generator
 		job.WithCgroup(fmt.Sprintf("/sys/fs/cgroup/telejob-%d", rand.Uint64())),
 	}
-	server, err := telejob.NewServer("testdata/server.crt", "testdata/server.key", clientCA, opts...)
+	if *address != "" {
+		return &testServer{address: *address}
+	}
+	server, err := telejob.NewServer("testdata/server.crt", "testdata/server.key", "testdata/client-ca.crt", opts...)
 	require.NoError(t, err)
-	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	lis, err := net.Listen("tcp", "localhost:0")
 	require.NoError(t, err)
 	go func() {
 		if err := server.Serve(lis); err != nil {

--- a/justfile
+++ b/justfile
@@ -21,9 +21,10 @@ build: out
 test name="":
        sudo bin/go test -v -race -count=1  -run={{name}} ./...
 
-# Stress test. `just stress 1000` runs with 1000 jobs.
-stress jobs:
+# Stress test. `just stress 10 20` runs with 10 jobs, 20 log reads.
+stress jobs="1000" readers="1000" address="":
        sudo bin/go test -v -race -count=1 -run="Many" ./pkg/job -jobs={{jobs}}
+       sudo bin/go test -v -race -count=1 -run="Many" ./cmd/telejob -readers={{readers}} -address={{address}}
 
 # Generate go code from proto files.
 proto:

--- a/pkg/job/logs.go
+++ b/pkg/job/logs.go
@@ -1,0 +1,188 @@
+package job
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"slices"
+)
+
+// channelWriter implements io.Writer by sending byte slices to a channel.
+type channelWriter chan []byte
+
+// Write implements io.Writer by sending the provided byte slice to the channel.
+//
+// A copy of the byte slice is sent to prevent race conditions.
+func (w channelWriter) Write(b []byte) (int, error) {
+	w <- slices.Clone(b) // Send a copy to avoid data races on the underlying array.
+	return len(b), nil
+}
+
+// logResponseCh is a channel for receiving log data.
+type logResponseCh chan []byte
+
+// logRequest represents a request for log data, specifying the starting index
+// and a channel for receiving the response.
+type logRequest struct {
+	startIdx uint64
+	respCh   logResponseCh
+}
+
+// logDispatcher distributes log data received on an input channel to multiple
+// readers.
+type logDispatcher struct {
+	inputCh chan []byte
+	reqCh   chan logRequest
+	doneCh  chan logResponseCh
+	fullLog []byte
+
+	// followers is a set of log response channels waiting to receive the next
+	// piece of future log data. Followers are removed from this set after the
+	// next piece of log data is sent.
+	followers map[logResponseCh]bool
+}
+
+// newStartedLogDispatcher creates and starts a new logDispatcher. The
+// dispatcher runs in its own goroutine.
+func newStartedLogDispatcher(inputCh chan []byte) *logDispatcher {
+	l := &logDispatcher{
+		inputCh:   inputCh,
+		reqCh:     make(chan logRequest),
+		doneCh:    make(chan logResponseCh),
+		followers: make(map[logResponseCh]bool),
+	}
+	go l.start()
+	return l
+}
+
+// start is the main loop of the logDispatcher, handling incoming log data,
+// requests for logs, and cleaning up log followers that are done.
+func (l *logDispatcher) start() {
+	for {
+		select {
+		case b, ok := <-l.inputCh:
+			if !ok {
+				l.handleInputClosed()
+			} else {
+				l.handleInput(b)
+			}
+		case req := <-l.reqCh:
+			l.handleRequest(req)
+		case respCh := <-l.doneCh:
+			if l.followers[respCh] {
+				delete(l.followers, respCh)
+				close(respCh)
+			}
+		}
+	}
+}
+
+// handleInput processes incoming log data.
+//
+// If the input channel is closed, it notifies all followers and cleans up.
+// Otherwise, it appends the new data to the full log and sends it to all
+// current followers.
+func (l *logDispatcher) handleInput(b []byte) {
+	l.fullLog = append(l.fullLog, b...)
+	for follower := range l.followers {
+		// A follower is always waiting for a response on a buffered channel,
+		// this never blocks.
+		follower <- b
+	}
+	clear(l.followers)
+}
+
+func (l *logDispatcher) handleInputClosed() {
+	l.inputCh = nil
+	for follower := range l.followers {
+		close(follower)
+	}
+	clear(l.followers)
+}
+
+// handleRequest processes a log request.
+//
+// If the requested data is already available, it is sent to the requester.
+// Otherwise, the requester is added as a follower to receive future log data.
+// If the input channel is closed, the response channel is closed immediately.
+func (l *logDispatcher) handleRequest(req logRequest) {
+	respCh := req.respCh
+	switch {
+	case req.startIdx < uint64(len(l.fullLog)):
+		respCh <- l.fullLog[req.startIdx:]
+	case l.inputCh != nil:
+		l.followers[respCh] = true
+	default:
+		close(respCh)
+	}
+}
+
+// newReader creates a new io.Reader for reading logs from the dispatcher.
+//
+// Each call to newReader creates a new, independent reader with its own
+// dedicated response channel. The provided context controls the lifetime of
+// the reader. When the context is cancelled, pending and subsequent calls to
+// Read will return an error.
+func (l *logDispatcher) newReader(ctx context.Context) io.Reader {
+	return &logReader{
+		startIdx:   0,
+		respCh:     make(logResponseCh, 1),
+		ctx:        ctx,
+		dispatcher: l,
+	}
+}
+
+// closeInput closes the log dispatcher's input channel, signaling that no more
+// log data will be received. This notifies any active log readers of the end
+// of the log stream. After calling closeInput, the dispatcher continues to
+// serve log requests from the buffered data in dispatcher.fullLog. The request
+// and done channels remain open to facilitate this.
+func (l *logDispatcher) closeInput() {
+	close(l.inputCh)
+}
+
+// logReader reads log data from a logDispatcher.
+//
+// A logReader requests log data in discrete chunks from the dispatcher using a
+// dedicated response channel. It maintains a start index to track the position
+// of the next read.
+type logReader struct {
+	startIdx   uint64
+	respCh     logResponseCh
+	ctx        context.Context //nolint:containedctx // The context is used to cancel Read.
+	dispatcher *logDispatcher
+}
+
+// Read reads log data from the dispatcher into p.
+//
+// It sends a request to the dispatcher for the next chunk of log data
+// starting from the reader's current start index. The reader then waits
+// for a response on its dedicated response channel.
+//
+// If the context is cancelled, Read returns an error wrapping the context
+// error. If the response channel is closed, Read returns io.EOF, indicating
+// the end of the log stream. Otherwise, Read copies the received data into p
+// and updates the start index.
+func (lr *logReader) Read(p []byte) (int, error) {
+	if lr.ctx.Err() != nil {
+		return 0, fmt.Errorf("log reader context already done: %w", lr.ctx.Err())
+	}
+	if lr.respCh == nil {
+		return 0, io.EOF
+	}
+	req := logRequest{startIdx: lr.startIdx, respCh: lr.respCh}
+	lr.dispatcher.reqCh <- req
+	select {
+	case <-lr.ctx.Done():
+		lr.dispatcher.doneCh <- req.respCh
+		return 0, fmt.Errorf("log reader context received done: %w", lr.ctx.Err())
+	case b, ok := <-lr.respCh:
+		if !ok {
+			lr.respCh = nil
+			return 0, io.EOF
+		}
+		n := copy(p, b)
+		lr.startIdx += uint64(n) //nolint:gosec // n cannot be negative.
+		return n, nil
+	}
+}

--- a/pkg/job/logs_test.go
+++ b/pkg/job/logs_test.go
@@ -1,0 +1,214 @@
+package job
+
+import (
+	"context"
+	"errors"
+	"io"
+	"math/rand"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLogsSimple(t *testing.T) {
+	t.Parallel()
+	inputCh := make(chan []byte)
+	go func() {
+		inputCh <- []byte("hello")
+		close(inputCh)
+	}()
+	dispatcher := newStartedLogDispatcher(inputCh)
+	r := dispatcher.newReader(context.Background())
+	b := make([]byte, 10)
+	n, err := r.Read(b)
+	require.NoError(t, err)
+	require.Equal(t, 5, n)
+	require.Equal(t, "hello", string(b[:n]))
+	_, err = r.Read(b)
+	require.ErrorIs(t, err, io.EOF)
+}
+
+func TestLogsNoInput(t *testing.T) {
+	t.Parallel()
+	inputCh := make(chan []byte)
+	go func() {
+		close(inputCh)
+	}()
+	dispatcher := newStartedLogDispatcher(inputCh)
+	r := dispatcher.newReader(context.Background())
+	b := make([]byte, 10)
+	n, err := r.Read(b)
+	require.ErrorIs(t, err, io.EOF)
+	require.Equal(t, 0, n)
+	require.Equal(t, "", string(b[:n]))
+}
+
+func TestLogsWithManyReaders(t *testing.T) {
+	t.Parallel()
+	const readerCount = 100
+
+	inputCh := make(chan []byte)
+	dispatcher := newStartedLogDispatcher(inputCh)
+	go func() {
+		inputCh <- []byte("hello")
+		close(inputCh)
+	}()
+	readers := make([]io.Reader, readerCount)
+	wg := &sync.WaitGroup{}
+	wg.Add(len(readers))
+	for i := range readers {
+		readers[i] = dispatcher.newReader(context.Background())
+		go func() {
+			requireRead(t, readers[i], 2, "hello")
+			wg.Done()
+		}()
+	}
+	waitWithTimeout(t, wg, time.Second*100)
+}
+
+func TestLogsWithManyDelayedReaders(t *testing.T) {
+	t.Parallel()
+	const readerCount = 100
+	const delay = 100 * time.Millisecond
+	const text = "Hello slow, slow world!"
+
+	inputCh := make(chan []byte)
+
+	dispatcher := newStartedLogDispatcher(inputCh)
+	go inputSlowly(inputCh, text, delay)
+	wg := &sync.WaitGroup{}
+	wg.Add(readerCount)
+	for range readerCount {
+		r := dispatcher.newReader(context.Background())
+		go func() {
+			sr := &slowReader{r: r, delay: time.Millisecond * 10}
+			requireRead(t, sr, 20, text)
+			wg.Done()
+		}()
+	}
+	waitWithTimeout(t, wg, time.Second*100)
+}
+
+type slowReader struct {
+	r     io.Reader
+	delay time.Duration
+}
+
+func (sr *slowReader) Read(b []byte) (int, error) {
+	if sr.delay > 0 {
+		randDelay := time.Duration(rand.Int63n(int64(sr.delay)))
+		time.Sleep(randDelay)
+	}
+	return sr.r.Read(b) //nolint:wrapcheck
+}
+
+func TestLogsWithCancel(t *testing.T) {
+	t.Parallel()
+	inputCh := make(chan []byte)
+	ctx, cancel := context.WithCancel(context.Background())
+	dispatcher := newStartedLogDispatcher(inputCh)
+
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
+	r := dispatcher.newReader(ctx)
+	go func() {
+		_, err := r.Read(make([]byte, 1))
+		if !errors.Is(err, context.Canceled) {
+			t.Errorf("TestLogsWithCancel: not a contextCancel error: %v", err)
+		}
+		wg.Done()
+	}()
+
+	cancel()
+	waitWithTimeout(t, wg, time.Second)
+
+	// ensure we can read historical logs
+	inputCh <- []byte("hi")
+	r = dispatcher.newReader(context.Background())
+	close(inputCh)
+	requireRead(t, r, 1, "hi")
+}
+
+type delayedTestCase struct {
+	name        string
+	input       string
+	inputDelay  time.Duration
+	outputDelay time.Duration
+}
+
+func TestLogsWithDelay(t *testing.T) {
+	t.Parallel()
+	input := "hello"
+	delay := time.Millisecond * 20
+	longerInput := strings.Repeat(input, 100)
+	shortDelay := time.Millisecond
+	testCases := []delayedTestCase{
+		{"no delay", input, 0, 0},
+		{"no input", "", 0, 0},
+		{"input delay", input, delay, 0},
+		{"output delay", input, 0, delay},
+		{"input and output delay", input, delay, delay},
+		{"long input", longerInput, shortDelay, shortDelay},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			inputCh := make(chan []byte)
+
+			go inputSlowly(inputCh, tc.input, tc.inputDelay)
+			dispatcher := newStartedLogDispatcher(inputCh)
+			r := dispatcher.newReader(context.Background())
+			rs := &slowReader{r: r, delay: tc.outputDelay}
+			requireRead(t, rs, 10, tc.input)
+		})
+	}
+}
+
+func inputSlowly(inputCh chan []byte, s string, delay time.Duration) {
+	b := []byte(s)
+	for i := range b {
+		inputCh <- b[i : i+1]
+		if delay > 0 {
+			randDelay := time.Duration(rand.Int63n(int64(delay)))
+			time.Sleep(randDelay)
+		}
+	}
+	close(inputCh)
+}
+
+func waitWithTimeout(t *testing.T, wg *sync.WaitGroup, timeout time.Duration) {
+	t.Helper()
+	c := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(c)
+	}()
+	select {
+	case <-c:
+		return
+	case <-time.After(timeout):
+		t.Fatalf("timed out waiting for wait group")
+	}
+}
+
+func requireRead(t *testing.T, r io.Reader, size int, want string) {
+	t.Helper()
+	b := make([]byte, size)
+	got := &strings.Builder{}
+	for {
+		n, err := r.Read(b)
+		if errors.Is(err, io.EOF) {
+			if want != got.String() {
+				t.Errorf("requireRead: want != got: \nwant: %v\ngot:  %v", want, got) // go-routine safe
+			}
+			return
+		} else if err != nil {
+			t.Errorf("requireRead: error: %v", err) // go-routine safe
+		}
+		got.Write(b[:n])
+	}
+}

--- a/pkg/telejob/telejob.go
+++ b/pkg/telejob/telejob.go
@@ -14,6 +14,9 @@ import (
 	"google.golang.org/grpc/credentials"
 )
 
+// LogChunkSize is the size of log chunks sent over the stream (16KB).
+const LogChunkSize = 16 * 1024
+
 // Sentinel Errors returned by the telejob package.
 var (
 	ErrCredentials = errors.New("credentials setup error")
@@ -21,6 +24,7 @@ var (
 	ErrCASetup     = errors.New("CA setup error")
 	ErrCommonName  = errors.New("failed to extract Common Name")
 	ErrClientConn  = errors.New("client connection error")
+	ErrStreamSend  = errors.New("cannot send on gRPC stream")
 )
 
 // Client is a wrapper around the generated gRPC client for the Telejob service.


### PR DESCRIPTION
Add a `telejob logs` command to retrieve and continuously print logs of a
running job or retrieve historical logs of a stopped job.

Implement the streaming `Logs` method of the gRPC service to stream log data to
the client CLI.

The service method calls the job controller's `Logs` method, which creates a
private `logDispatcher` for each job. The `logDispatcher` retrieves `Stdout`
and `Stderr` from the job's process and dispatches this output to all readers,
ultimately sending it on the gRPC server stream.

Write tests, stress tests, and documentation for the new feature.